### PR TITLE
Add npm scripts for playwright and puppeteer with --url parameter support

### DIFF
--- a/experiments/test-all-arg-formats.sh
+++ b/experiments/test-all-arg-formats.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Script to test various argument passing formats
+
+echo "=== Test 1: Direct node execution with --url ==="
+node experiments/test-npm-config.js --url https://direct.example.com
+echo ""
+
+echo "=== Test 2: npm run with -- and --url ==="
+npm run --silent playwright -- --url https://with-separator.example.com --help
+echo ""
+
+echo "=== Test 3: npm run with --url (no --) - npm config approach ==="
+npm_config_url=https://npm-config.example.com node experiments/test-npm-config.js
+echo ""
+
+echo "=== Test 4: Using -u alias ==="
+node experiments/test-npm-config.js -u https://alias.example.com

--- a/experiments/test-exact-user-syntax.sh
+++ b/experiments/test-exact-user-syntax.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Test the exact syntax requested by the user
+TEST_URL="https://hh.ru/search/vacancy?resume=80d55a81ff0171bfa80039ed1f743266675357&from=resumelist"
+
+echo "=== Testing exact user syntax ==="
+echo "Command: npm run playwright --url $TEST_URL"
+echo ""
+
+# Create a temporary package.json entry for testing
+cat > /tmp/test-package.json <<EOF
+{
+  "scripts": {
+    "test-playwright": "node experiments/test-playwright-args.js"
+  }
+}
+EOF
+
+# Test with npm config approach (user requested syntax without --)
+echo "Test Result:"
+npm_config_url="$TEST_URL" node experiments/test-playwright-args.js
+echo ""
+
+echo "=== Testing with -- separator (alternative syntax) ==="
+echo "Command: npm run playwright -- --url $TEST_URL"
+echo ""
+echo "Test Result:"
+node experiments/test-playwright-args.js --url "$TEST_URL"

--- a/experiments/test-npm-config.js
+++ b/experiments/test-npm-config.js
@@ -1,0 +1,18 @@
+// Test to see if npm passes --url as a config option
+console.log('npm_config_url:', process.env.npm_config_url);
+console.log('process.argv:', process.argv);
+
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const argv = yargs(hideBin(process.argv))
+  .option('url', {
+    alias: 'u',
+    type: 'string',
+    description: 'URL to navigate to',
+    default: process.env.npm_config_url || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist'
+  })
+  .help()
+  .argv;
+
+console.log('Parsed URL:', argv.url);

--- a/experiments/test-npm-script-args.sh
+++ b/experiments/test-npm-script-args.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "=== Test 1: npm run with --url parameter ==="
+npm run playwright -- --url https://example.com --help
+
+echo ""
+echo "=== Test 2: Check if help works ==="
+npm run playwright -- --help
+
+echo ""
+echo "=== Test 3: Using alias -u ==="
+npm run playwright -- -u https://example.com --help

--- a/experiments/test-playwright-args.js
+++ b/experiments/test-playwright-args.js
@@ -1,0 +1,20 @@
+// Minimal test to verify playwright script argument parsing without launching browser
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const argv = yargs(hideBin(process.argv))
+  .option('url', {
+    alias: 'u',
+    type: 'string',
+    description: 'URL to navigate to',
+    default: process.env.npm_config_url || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist'
+  })
+  .help()
+  .argv;
+
+const MESSAGE = process.env.MESSAGE || 'В какой форме предлагается юридическое оформление удалённой работы?';
+const START_URL = argv.url;
+
+console.log('✅ Playwright test script');
+console.log('   URL:', START_URL);
+console.log('   Message:', MESSAGE);

--- a/experiments/test-yargs-parsing.js
+++ b/experiments/test-yargs-parsing.js
@@ -1,0 +1,17 @@
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+// Test script to verify yargs argument parsing
+const argv = yargs(hideBin(process.argv))
+  .option('url', {
+    alias: 'u',
+    type: 'string',
+    description: 'URL to navigate to',
+    default: process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist'
+  })
+  .help()
+  .argv;
+
+console.log('Parsed arguments:');
+console.log('  --url:', argv.url);
+console.log('\nFull argv object:', argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "hhru-automation",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "UNLICENSE",
       "devDependencies": {
         "playwright": "^1.56.1",
-        "puppeteer": "^24.27.0"
+        "puppeteer": "^24.27.0",
+        "yargs": "^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -60,6 +61,129 @@
         "node": ">=18"
       }
     },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -100,26 +224,26 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -302,18 +426,18 @@
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -414,9 +538,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -587,6 +711,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -1069,31 +1206,37 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/tar-fs": {
@@ -1163,18 +1306,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -1220,32 +1363,31 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "devDependencies": {
     "playwright": "^1.56.1",
-    "puppeteer": "^24.27.0"
+    "puppeteer": "^24.27.0",
+    "yargs": "^18.0.0"
   }
 }

--- a/playwright-click-and-type.js
+++ b/playwright-click-and-type.js
@@ -1,25 +1,22 @@
 const { chromium } = require('playwright');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
 
 (async () => {
-  // Parse command-line arguments
-  const args = process.argv.slice(2);
-  let urlFromArgs = null;
-
-  // Check for --url argument
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--url' && i + 1 < args.length) {
-      urlFromArgs = args[i + 1];
-      break;
-    }
-  }
-
-  // If no --url found, check if first argument is a URL (npm strips --url when used without --)
-  if (!urlFromArgs && args.length > 0 && args[0].startsWith('http')) {
-    urlFromArgs = args[0];
-  }
+  // Parse command-line arguments using yargs
+  // npm passes --url as npm_config_url when used without --
+  const argv = yargs(hideBin(process.argv))
+    .option('url', {
+      alias: 'u',
+      type: 'string',
+      description: 'URL to navigate to',
+      default: process.env.npm_config_url || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist'
+    })
+    .help()
+    .argv;
 
   const MESSAGE = process.env.MESSAGE || 'В какой форме предлагается юридическое оформление удалённой работы?';
-  const START_URL = urlFromArgs || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist';
+  const START_URL = argv.url;
 
   const browser = await chromium.launch({ headless: false, slowMo: 150 });
   const page = await browser.newPage();

--- a/puppeteer-click-and-type.js
+++ b/puppeteer-click-and-type.js
@@ -1,25 +1,22 @@
 const puppeteer = require('puppeteer');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
 
 (async () => {
-  // Parse command-line arguments
-  const args = process.argv.slice(2);
-  let urlFromArgs = null;
-
-  // Check for --url argument
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--url' && i + 1 < args.length) {
-      urlFromArgs = args[i + 1];
-      break;
-    }
-  }
-
-  // If no --url found, check if first argument is a URL (npm strips --url when used without --)
-  if (!urlFromArgs && args.length > 0 && args[0].startsWith('http')) {
-    urlFromArgs = args[0];
-  }
+  // Parse command-line arguments using yargs
+  // npm passes --url as npm_config_url when used without --
+  const argv = yargs(hideBin(process.argv))
+    .option('url', {
+      alias: 'u',
+      type: 'string',
+      description: 'URL to navigate to',
+      default: process.env.npm_config_url || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist'
+    })
+    .help()
+    .argv;
 
   const MESSAGE = process.env.MESSAGE || 'В какой форме предлагается юридическое оформление удалённой работы?';
-  const START_URL = urlFromArgs || process.env.START_URL || 'https://hh.ru/search/vacancy?from=resumelist';
+  const START_URL = argv.url;
 
   const browser = await puppeteer.launch({ headless: false, defaultViewport: null, args: ['--start-maximized'] });
   const [page] = await browser.pages();


### PR DESCRIPTION
## 🎯 Summary

This PR implements npm scripts that allow running automation tools with custom URLs for both Playwright and Puppeteer, with visible browser windows for monitoring.

### 📋 Issue Reference
Fixes #2

## ✨ Changes

### Package.json
- Added `yargs` as a devDependency for robust argument parsing
- Added `playwright` script: `npm run playwright --url <URL>`
- Added `puppeteer` script: `npm run puppeteer --url <URL>`

### Script Enhancements
Both `playwright-click-and-type.js` and `puppeteer-click-and-type.js` now:
- Use **yargs** library for command-line argument parsing
- Parse `--url` command-line argument with proper help text
- Support multiple invocation syntaxes (see Usage below)
- Support `-u` alias for `--url` option
- Maintain backward compatibility with `START_URL` environment variable
- Continue to run with visible browsers (`headless: false`)

### Test Coverage
Added comprehensive test scripts in `experiments/` directory to verify:
- Direct node execution with arguments
- npm run with various argument formats
- Argument parsing with yargs
- npm config variable support

## 🔧 Usage

### Playwright

```bash
# Using npm config (recommended syntax from issue)
npm run playwright --url https://hh.ru/search/vacancy?resume=80d55a81ff0171bfa80039ed1f743266675357&from=resumelist

# Using -- separator (alternative)
npm run playwright -- --url https://hh.ru/search/vacancy?resume=80d55a81ff0171bfa80039ed1f743266675357&from=resumelist

# Using alias
npm run playwright -- -u https://example.com

# Direct node execution
node playwright-click-and-type.js --url https://example.com

# Show help
npm run playwright -- --help
```

### Puppeteer

```bash
# Using npm config (recommended syntax from issue)
npm run puppeteer --url https://hh.ru/search/vacancy?resume=80d55a81ff0171bfa80039ed1f743266675357&from=resumelist

# Using -- separator (alternative)
npm run puppeteer -- --url https://hh.ru/search/vacancy?resume=80d55a81ff0171bfa80039ed1f743266675357&from=resumelist

# Using alias
npm run puppeteer -- -u https://example.com

# Direct node execution
node puppeteer-click-and-type.js --url https://example.com

# Show help
npm run puppeteer -- --help
```

## ✅ Features

- **Yargs Integration**: Professional argument parsing with built-in help
- **URL Parameter Support**: Both scripts accept `--url` or `-u` argument
- **Visible Browser**: Both scripts run with `headless: false` so you can monitor the automation
- **Backward Compatible**: Still works with `START_URL` environment variable
- **Multiple Syntaxes**: Supports npm config, direct arguments, and aliases
- **Built-in Help**: Run with `--help` to see all options
- **Fallback URL**: Uses default URL if no parameter provided

## 🔍 Technical Details

The implementation uses the **yargs** library as requested in PR feedback. The parsing logic handles:
1. Explicit `--url <value>` or `-u <value>` syntax
2. npm config variables (`npm_config_url`) when using `npm run script --url <value>`
3. `START_URL` environment variable (backward compatibility)
4. Default fallback URL

The `hideBin()` helper from yargs properly handles the node and script arguments, and yargs provides automatic help generation and type validation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)