### PR TITLE
Replace message to this one

### DIFF
--- a/playwright-click-and-type.js
+++ b/playwright-click-and-type.js
@@ -47,7 +47,14 @@ process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
     .help()
     .argv;
 
-  const MESSAGE = process.env.MESSAGE || 'В какой форме предлагается юридическое оформление удалённой работы?';
+  const MESSAGE = process.env.MESSAGE || `В какой форме предлагается юридическое оформление удалённой работы?
+
+Посмотреть мой код на GitHub можно тут:
+
+github.com/konard
+github.com/deep-assistant
+github.com/linksplatform
+github.com/link-foundation`;
   const START_URL = argv.url;
 
   // Set environment variables to suppress "Google API keys are missing" warning

--- a/puppeteer-click-and-type.js
+++ b/puppeteer-click-and-type.js
@@ -47,7 +47,14 @@ process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
     .help()
     .argv;
 
-  const MESSAGE = process.env.MESSAGE || 'В какой форме предлагается юридическое оформление удалённой работы?';
+  const MESSAGE = process.env.MESSAGE || `В какой форме предлагается юридическое оформление удалённой работы?
+
+Посмотреть мой код на GitHub можно тут:
+
+github.com/konard
+github.com/deep-assistant
+github.com/linksplatform
+github.com/link-foundation`;
   const START_URL = argv.url;
 
   // Launch browser with persistent user data directory to save cookies and session data


### PR DESCRIPTION
## Summary

This pull request implements the solution for issue #1 - replacing the automation message with a new multi-line message that includes GitHub profile links.

### Changes
- Updated the default MESSAGE value in `playwright-click-and-type.js` to include GitHub profile links
- Updated the default MESSAGE value in `puppeteer-click-and-type.js` to include GitHub profile links

### New Message
The automation scripts now use this message by default:
```
В какой форме предлагается юридическое оформление удалённой работы?

Посмотреть мой код на GitHub можно тут:

github.com/konard
github.com/deep-assistant
github.com/linksplatform
github.com/link-foundation
```

### Technical Details
- The MESSAGE can still be overridden via the `MESSAGE` environment variable
- Both automation engines (Puppeteer and Playwright) now use the same updated message format
- The message is typed into the application response textarea before submission

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)